### PR TITLE
Adding support for fully escaped URL query parameter values

### DIFF
--- a/lib/stir/core_ext/string.rb
+++ b/lib/stir/core_ext/string.rb
@@ -6,7 +6,7 @@ module CoreExt
         return self if match.nil?
         key = $1.tr('{}', '').to_sym
         raise KeyError.new("key{#{key}} not found") unless h.has_key?(key)
-        h[key]
+        CGI::escape(h[key])
       end
     end
   end

--- a/lib/stir/rest/endpoints.rb
+++ b/lib/stir/rest/endpoints.rb
@@ -42,7 +42,7 @@ module Stir
       private
       def endpoint(name, method, &block)
         send(:define_method, name) do |*args|
-          @response = HTTParty.send(method, URI.escape(yield.interpolate(args.first)), merge_configs(args.flatten.first))
+          @response = HTTParty.send(method, yield.interpolate(args.first), merge_configs(args.flatten.first))
         end
         endpoints.push({name => yield.to_s})
       end


### PR DESCRIPTION
Currently, the whole URL query param string is escaped using `URI.escape` 

This does not escape any `&` in a URL parameter value. 

I removed URI.escape from the whole URL parameter string before it goes to HTTParty and added CGI::escape in the interpolate method for each URL parameter value.